### PR TITLE
Nvidia Cuda Update to Latest on Ubuntu 18.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # Author: Nikolaus Mayer (2018), mayern@cs.uni-freiburg.de
 #######################################################################
 
-FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:11.4.1-cudnn8-devel-ubuntu18.04
+
+## Older version nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
 ## Container's mount points for the host's input/output folders
 VOLUME "/input"


### PR DESCRIPTION
same OS as base docker image so it will not break it.
11.4.1-cudnn8-devel-ubuntu18.04